### PR TITLE
Update package.json dependency and .npmrc settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-node-linker=hoisted
 legacy-peer-deps=true

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
-    "@wireservers-ui/react-native-ui": "workspace:*",
+    "@wireservers-ui/react-native-ui": "*",
     "expo": "~54.0.33",
     "expo-clipboard": "^8.0.8",
     "expo-constants": "~18.0.13",


### PR DESCRIPTION
Update the dependency for `@wireservers-ui/react-native-ui` to use a wildcard and remove the `node-linker` setting from `.npmrc`.