### PR TITLE
Integrate Google Tag Manager for enhanced tracking and analytics

### DIFF
--- a/demos/expo/app/+html.tsx
+++ b/demos/expo/app/+html.tsx
@@ -1,10 +1,25 @@
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 
+const GTM_ID = 'GTM-PTXVFC3R';
+
 export default function Root({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <head>
+        {/* Google Tag Manager — must be first in <head> to avoid missed events */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','${GTM_ID}');
+            `,
+          }}
+        />
+
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         <meta
@@ -97,18 +112,8 @@ export default function Root({ children }: PropsWithChildren) {
         />
         <ScrollViewStyleReset />
 
-        {/* Google Analytics */}
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-J8J88W24VR" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-              gtag('config', 'G-J8J88W24VR');
-            `,
-          }}
-        />
+        {/* NOTE: Google Analytics (G-J8J88W24VR) should be configured inside GTM container
+           rather than loaded as a standalone snippet to avoid double-counting */}
 
         {/* Clarity tracking code for https://www.reactnatives.dev/ */}
         <script
@@ -123,7 +128,19 @@ export default function Root({ children }: PropsWithChildren) {
           }}
         />
       </head>
-      <body>{children}</body>
+      <body>
+        {/* Google Tag Manager (noscript) */}
+        <noscript>
+          <iframe
+            src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+            title="Google Tag Manager"
+            height={0}
+            width={0}
+            style={{ display: 'none' }}
+          />
+        </noscript>
+        {children}
+      </body>
     </html>
   );
 }

--- a/demos/expo/app/+html.tsx
+++ b/demos/expo/app/+html.tsx
@@ -109,6 +109,19 @@ export default function Root({ children }: PropsWithChildren) {
             `,
           }}
         />
+
+        {/* Clarity tracking code for https://www.reactnatives.dev/ */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+              })(window, document, "clarity", "script", "vtvmzxw2aa");
+            `,
+          }}
+        />
       </head>
       <body>{children}</body>
     </html>


### PR DESCRIPTION
This pull request updates the analytics and tracking setup in the `demos/expo/app/+html.tsx` file. The main changes are the integration of Google Tag Manager (GTM) and a shift in how Google Analytics is loaded, along with the addition of Microsoft Clarity tracking. These updates ensure better tracking management and avoid double-counting analytics events.

**Analytics and Tracking Integration:**

* Added Google Tag Manager (GTM) script to the `<head>` and corresponding noscript iframe to the `<body>`, centralizing analytics and tracking management. [[1]](diffhunk://#diff-a067d104df9d2ffe79d4ccf934104812dae828d6255f2395eeba05240ac34c92R4-R22) [[2]](diffhunk://#diff-a067d104df9d2ffe79d4ccf934104812dae828d6255f2395eeba05240ac34c92L100-R143)
* Removed standalone Google Analytics snippet and included a note to configure it within the GTM container to prevent double-counting of events.

**Additional Tracking:**

* Added Microsoft Clarity tracking code for user behavior analytics on `https://www.reactnatives.dev/`.