### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [dev, prod, sot]
+  pull_request:
+    branches: [dev, prod, sot]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -38,11 +38,12 @@ const NAV_LINKS = [
   { label: "Components", path: "/components" },
 ];
 
-const RAW_REACT_NATIVES_VERSION =
-  require("../../packages/react-natives/package.json").version as
-    | string
-    | undefined;
-const REACT_NATIVES_NPM_VERSION = RAW_REACT_NATIVES_VERSION ?? "unknown";
+const RAW_REACT_NATIVES_VERSION = require("../package.json").dependencies?.[
+  "@wireservers-ui/react-natives"
+] as string | undefined;
+const REACT_NATIVES_NPM_VERSION = (
+  RAW_REACT_NATIVES_VERSION ?? "unknown"
+).replace(/^[~^]/, "");
 
 function SunIcon({ color, size = 18 }: { color: string; size?: number }) {
   return (

--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -38,12 +38,11 @@ const NAV_LINKS = [
   { label: "Components", path: "/components" },
 ];
 
-const RAW_REACT_NATIVES_VERSION = require("../package.json").dependencies?.[
-  "@wireservers-ui/react-natives"
-] as string | undefined;
-const REACT_NATIVES_NPM_VERSION = (
-  RAW_REACT_NATIVES_VERSION ?? "unknown"
-).replace(/^[~^]/, "");
+const RAW_REACT_NATIVES_VERSION =
+  require("../../packages/react-natives/package.json").version as
+    | string
+    | undefined;
+const REACT_NATIVES_NPM_VERSION = RAW_REACT_NATIVES_VERSION ?? "unknown";
 
 function SunIcon({ color, size = 18 }: { color: string; size?: number }) {
   return (


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` to run CodeQL analysis on `javascript-typescript`
- Triggers on push/PR to `dev`, `prod`, `sot` and weekly on Mondays
- Satisfies the `code_scanning` rule in the "Code Prevention" ruleset — future PRs to protected branches will no longer need admin bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)