### PR TITLE
ci: upgrade CodeQL action v3 → v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,14 +21,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"

--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -38,11 +38,12 @@ const NAV_LINKS = [
   { label: "Components", path: "/components" },
 ];
 
-const RAW_REACT_NATIVES_VERSION =
-  require("../../packages/react-natives/package.json").version as
-    | string
-    | undefined;
-const REACT_NATIVES_NPM_VERSION = RAW_REACT_NATIVES_VERSION ?? "unknown";
+const RAW_REACT_NATIVES_VERSION = require("../package.json").dependencies?.[
+  "@wireservers-ui/react-natives"
+] as string | undefined;
+const REACT_NATIVES_NPM_VERSION = (
+  RAW_REACT_NATIVES_VERSION ?? "unknown"
+).replace(/^[~^]/, "");
 
 function SunIcon({ color, size = 18 }: { color: string; size?: number }) {
   return (

--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -38,12 +38,11 @@ const NAV_LINKS = [
   { label: "Components", path: "/components" },
 ];
 
-const RAW_REACT_NATIVES_VERSION = require("../package.json").dependencies?.[
-  "@wireservers-ui/react-natives"
-] as string | undefined;
-const REACT_NATIVES_NPM_VERSION = (
-  RAW_REACT_NATIVES_VERSION ?? "unknown"
-).replace(/^[~^]/, "");
+const RAW_REACT_NATIVES_VERSION =
+  require("../../packages/react-natives/package.json").version as
+    | string
+    | undefined;
+const REACT_NATIVES_NPM_VERSION = RAW_REACT_NATIVES_VERSION ?? "unknown";
 
 function SunIcon({ color, size = 18 }: { color: string; size?: number }) {
   return (


### PR DESCRIPTION
## Summary

- Upgrades all `github/codeql-action` references from `v3` to `v4`
- v3 is deprecated and will be removed in December 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)