### PR TITLE
fix: rewrite prod_sync_dev to open a PR instead of pushing directly

### DIFF
--- a/.github/workflows/prod_sync_dev.yml
+++ b/.github/workflows/prod_sync_dev.yml
@@ -5,43 +5,25 @@ on:
     branches: [prod]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout dev
-        uses: actions/checkout@v4
-        with:
-          ref: dev
-          fetch-depth: 0
-
-      - name: Merge prod into dev
-        id: merge
+      - name: Open back-sync PR if not already open
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin prod
-          if git merge --no-edit origin/prod; then
-            echo "merged=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "merged=false" >> "$GITHUB_OUTPUT"
+          existing=$(gh pr list --head prod --base dev --state open --json number --jq '.[0].number')
+          if [[ -n "$existing" ]]; then
+            echo "Back-sync PR #$existing already open, skipping."
+            exit 0
           fi
-
-      - name: Push dev
-        if: steps.merge.outputs.merged == 'true'
-        run: git push origin dev
-
-      - name: Open conflict PR if merge failed
-        if: steps.merge.outputs.merged == 'false'
-        run: |
-          git merge --abort || true
           gh pr create \
-            --title "chore: sync prod → dev (conflicts need resolution)" \
-            --body "Automatic back-merge of \`prod\` into \`dev\` failed due to conflicts. Please resolve manually." \
+            --title "chore: sync prod → dev" \
+            --body "Automatic back-merge of \`prod\` into \`dev\` to keep branches in sync after a promotion." \
             --head prod \
             --base dev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -38,11 +38,12 @@ const NAV_LINKS = [
   { label: "Components", path: "/components" },
 ];
 
-const RAW_REACT_NATIVES_VERSION =
-  require("../../packages/react-natives/package.json").version as
-    | string
-    | undefined;
-const REACT_NATIVES_NPM_VERSION = RAW_REACT_NATIVES_VERSION ?? "unknown";
+const RAW_REACT_NATIVES_VERSION = require("../package.json").dependencies?.[
+  "@wireservers-ui/react-natives"
+] as string | undefined;
+const REACT_NATIVES_NPM_VERSION = (
+  RAW_REACT_NATIVES_VERSION ?? "unknown"
+).replace(/^[~^]/, "");
 
 function SunIcon({ color, size = 18 }: { color: string; size?: number }) {
   return (

--- a/website/components/header.tsx
+++ b/website/components/header.tsx
@@ -38,12 +38,11 @@ const NAV_LINKS = [
   { label: "Components", path: "/components" },
 ];
 
-const RAW_REACT_NATIVES_VERSION = require("../package.json").dependencies?.[
-  "@wireservers-ui/react-natives"
-] as string | undefined;
-const REACT_NATIVES_NPM_VERSION = (
-  RAW_REACT_NATIVES_VERSION ?? "unknown"
-).replace(/^[~^]/, "");
+const RAW_REACT_NATIVES_VERSION =
+  require("../../packages/react-natives/package.json").version as
+    | string
+    | undefined;
+const REACT_NATIVES_NPM_VERSION = RAW_REACT_NATIVES_VERSION ?? "unknown";
 
 function SunIcon({ color, size = 18 }: { color: string; size?: number }) {
   return (


### PR DESCRIPTION
## Summary

- Rewrites `prod_sync_dev.yml` to open a `prod → dev` PR instead of trying to push directly to `dev`
- Direct pushes are blocked by branch protection (no merge commits, must go through a PR)
- Skips creating a duplicate if a back-sync PR is already open

🤖 Generated with [Claude Code](https://claude.com/claude-code)